### PR TITLE
Configure Dependabot for Python and GitHub Actions (Francisco)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 5
+    reviewers:
+      - "MeryylleA"
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 3
+    reviewers:
+      - "MeryylleA"
+    commit-message:
+      prefix: "chore(actions)"
+      include: "scope"


### PR DESCRIPTION
This commit introduces the Dependabot configuration file (`dependabot.yml`) to enable automated dependency updates for the project.

Configuration includes:
- Monitoring Python dependencies (`pip`) defined in `requirements.txt` (located in the root directory).
- Monitoring GitHub Actions used in workflows.
- Daily checks for updates for both ecosystems.
- A limit on the number of open pull requests Dependabot can create for each ecosystem.
- Assigning @MeryylleA as the reviewer for these PRs.
- Standardized commit message prefixes (`chore(deps)` for pip, `chore(actions)` for GitHub Actions).

This will help keep project dependencies secure and up-to-date with less manual effort. Auto-merge for Dependabot PRs is not enabled at this time and will be handled manually after CI checks.