### PR TITLE
Feat: Add model loading and prepare BPEProcessor for tokenization

### DIFF
--- a/bpe_trainer/bpe_trainer.cpp
+++ b/bpe_trainer/bpe_trainer.cpp
@@ -29,38 +29,57 @@ struct BpeStats {
     std::chrono::milliseconds training_time{0};
 };
 
-// BPE Trainer Class
-class BpeTrainer {
+// BPE Processor Class
+class BpeProcessor {
 public:
-    // Constructor now takes byte_level_mode
-    BpeTrainer(bool verbose = false, bool byte_level_mode = true)
-    : verbose_(verbose), byte_level_training_mode_(byte_level_mode) {}
+    BpeProcessor(bool verbose = false)
+    : verbose_(verbose), byte_level_processing_mode_(true), model_loaded_(false) {}
 
-    // train function no longer needs byte_level as a parameter
+    // --- Training Functionality ---
     bool train(const std::string& corpus_path,
-               const std::string& output_dir,
-               size_t target_vocab_size_param) {
+               const std::string& output_dir_or_prefix,
+               size_t target_vocab_size_param,
+               bool byte_level_training_mode) {
 
         auto overall_start_time = std::chrono::high_resolution_clock::now();
-        stats_ = BpeStats{}; // Reset stats for a new training run
+        stats_ = BpeStats{};
+        training_vocab_.clear();
+        learned_merges_for_saving_.clear();
+        token_to_id_.clear();
+        id_to_token_.clear();
+        loaded_merges_for_tokenizing_.clear();
+        model_loaded_ = false;
+
+        this->byte_level_processing_mode_ = byte_level_training_mode;
 
         if (verbose_) {
             consoleLog("Starting BPE training process...");
-            consoleLog("Mode: " + std::string(this->byte_level_training_mode_ ? "Byte-level" : "Word-level"));
+            consoleLog("Mode: " + std::string(this->byte_level_processing_mode_ ? "Byte-level" : "Word-level"));
             consoleLog("Loading corpus from file: " + corpus_path);
         }
 
-        if (!ensureOutputDirectory(output_dir)) return false;
+        std::string actual_output_dir;
+        std::string file_prefix;
+        if (output_dir_or_prefix.empty() || output_dir_or_prefix.back() == '/' || output_dir_or_prefix.back() == '\\') {
+            actual_output_dir = output_dir_or_prefix;
+            if (actual_output_dir.empty()) actual_output_dir = "./bpe_lunaris_model/";
+            file_prefix = "";
+        } else {
+            fs::path p(output_dir_or_prefix);
+            actual_output_dir = p.parent_path().string();
+            if (actual_output_dir.empty()) actual_output_dir = ".";
+            file_prefix = p.filename().string() + "_";
+        }
+        if (!ensureOutputDirectory(actual_output_dir)) return false;
 
-        // loadAndPretokenizeCorpus now uses the member variable this->byte_level_training_mode_
-        if (!loadAndPretokenizeCorpus(corpus_path)) {
+
+        if (!this->loadAndPretokenizeCorpus(corpus_path)) { // CORRECTED
             consoleErr("Error: Failed to load or pretokenize the corpus.");
             return false;
         }
 
-        // initializeVocabularyFromPretokenizedCorpus also uses the member variable
-        initializeVocabularyFromPretokenizedCorpus();
-        stats_.initial_vocab_size = vocab_.size();
+        this->initializeVocabularyFromPretokenizedCorpus(); // CORRECTED
+        stats_.initial_vocab_size = training_vocab_.size();
 
         if (verbose_) {
             consoleLog("Corpus loaded. Raw characters read: " + std::to_string(stats_.raw_corpus_char_count));
@@ -77,23 +96,22 @@ public:
             consoleLog("Effective target vocabulary size for merging: " + std::to_string(actual_target_vocab_size));
         }
 
-
-        if (actual_target_vocab_size <= vocab_.size()){
+        if (actual_target_vocab_size <= training_vocab_.size()){
             if (verbose_) {
                 consoleLog("Target vocabulary size (" + std::to_string(actual_target_vocab_size) +
-                ") is already met or exceeded by initial vocabulary (" + std::to_string(vocab_.size()) + "). No merges will be performed.");
+                ") is already met or exceeded by initial vocabulary (" + std::to_string(training_vocab_.size()) + "). No merges will be performed.");
             }
         } else {
             if (verbose_) consoleLog("Starting BPE merge iterations...");
-            while (vocab_.size() < actual_target_vocab_size) {
-                auto pair_counts = countAdjacentPairs();
+            while (training_vocab_.size() < actual_target_vocab_size) {
+                auto pair_counts = this->countAdjacentPairs(); // CORRECTED
                 if (pair_counts.empty()) {
                     if (verbose_) consoleLog("No more pairs to merge. Stopping iterations.");
                     break;
                 }
 
-                auto best_pair_info = findMostFrequentPair(pair_counts);
-                if (best_pair_info.first.first.empty() || best_pair_info.second <= 1) { // Stop if best pair is insignificant
+                auto best_pair_info = this->findMostFrequentPair(pair_counts); // CORRECTED
+                if (best_pair_info.first.first.empty() || best_pair_info.second <= 1) {
                     if (verbose_) consoleLog("No more significantly frequent pairs (frequency > 1) to merge. Stopping iterations.");
                     break;
                 }
@@ -101,32 +119,22 @@ public:
                 const auto& pair_to_merge = best_pair_info.first;
                 std::string new_token = pair_to_merge.first + pair_to_merge.second;
 
-                if (vocab_.count(new_token)) {
-                    if (verbose_ && stats_.total_merges < 5 + stats_.initial_vocab_size) { // Log first few occurrences of this
+                if (training_vocab_.count(new_token)) {
+                    if (verbose_ && stats_.total_merges < 5 + stats_.initial_vocab_size) {
                         consoleLog("Skipping merge: new token '" + escapeTokenForDisplay(new_token) + "' already in vocab. This can happen.");
                     }
-                    // To prevent potential infinite loops if the most frequent pair always creates an existing token:
-                    // A more robust solution would be to remove this pair from consideration and find the next best.
-                    // For now, we rely on the loop eventually breaking if no *new* tokens can be formed above freq 1.
-                    // If all top pairs form existing tokens, best_pair_info.second might not decrease,
-                    // but if only pairs with freq 1 remain, it will break.
-                    // Let's check if any other viable merge exists
                     bool found_other_merge = false;
                     for(const auto& pc_entry : pair_counts){
-                        if(pc_entry.second > 1 && !vocab_.count(pc_entry.first.first + pc_entry.first.second)){
+                        if(pc_entry.second > 1 && !training_vocab_.count(pc_entry.first.first + pc_entry.first.second)){
                             found_other_merge = true;
                             break;
                         }
                     }
-                    if(!found_other_merge && best_pair_info.second > 1){ // If best is still >1 but all new tokens from it are in vocab
+                    if(!found_other_merge && best_pair_info.second > 1){
                         if(verbose_) consoleLog("All remaining frequent pairs (freq > 1) result in existing tokens. Stopping iterations to prevent stall.");
                         break;
                     }
-                    // If the best pair creates an existing token, but other *new* tokens could be formed from other pairs,
-                    // ideally we'd remove the current best_pair from pair_counts and re-iterate findMostFrequentPair.
-                    // For simplicity now, we let it try (it won't add to vocab, loop continues). If it gets stuck, the above check helps.
                 }
-
 
                 if (verbose_) {
                     consoleLog("Merge #" + std::to_string(stats_.total_merges + 1) +
@@ -136,36 +144,129 @@ public:
                     "' (Frequency: " + std::to_string(best_pair_info.second) + ")");
                 }
 
-                applyMergeToCorpus(pair_to_merge.first, pair_to_merge.second, new_token);
-
-                learned_merges_.push_back(pair_to_merge);
+                this->applyMergeToCorpus(pair_to_merge.first, pair_to_merge.second, new_token); // CORRECTED
+                learned_merges_for_saving_.push_back(pair_to_merge);
                 stats_.total_merges++;
-                vocab_.insert(new_token); // Will only insert if new_token isn't already there
+                training_vocab_.insert(new_token);
 
-                if (verbose_ && (stats_.total_merges % 100 == 0 || vocab_.size() % std::max((size_t)1, actual_target_vocab_size/100) == 0) ) {
-                    consoleLog("Progress: " + std::to_string(vocab_.size()) + "/" + std::to_string(actual_target_vocab_size) +
-                    " vocab tokens (" + formatDouble(vocab_.size() * 100.0 / actual_target_vocab_size, 2) + "%)");
+                if (verbose_ && (stats_.total_merges % 100 == 0 || training_vocab_.size() % std::max((size_t)1, actual_target_vocab_size/100) == 0) ) {
+                    consoleLog("Progress: " + std::to_string(training_vocab_.size()) + "/" + std::to_string(actual_target_vocab_size) +
+                    " vocab tokens (" + formatDouble(training_vocab_.size() * 100.0 / actual_target_vocab_size, 2) + "%)");
                 }
             }
         }
 
-
-        stats_.final_vocab_size = vocab_.size();
+        stats_.final_vocab_size = training_vocab_.size();
         auto overall_end_time = std::chrono::high_resolution_clock::now();
         stats_.training_time = std::chrono::duration_cast<std::chrono::milliseconds>(overall_end_time - overall_start_time);
 
-        if (verbose_) printStats();
-        saveResults(output_dir);
+        if (verbose_) this->printStats(); // CORRECTED
+        saveTrainingResults(actual_output_dir, file_prefix);
         return true;
+               }
+
+               bool load_model(const std::string& model_path_or_dir) {
+                   token_to_id_.clear();
+                   id_to_token_.clear();
+                   loaded_merges_for_tokenizing_.clear();
+                   model_loaded_ = false;
+
+                   fs::path model_fs_path(model_path_or_dir);
+                   std::string json_model_file_path;
+
+                   if (fs::is_directory(model_fs_path)) {
+                       json_model_file_path = (model_fs_path / "bpe_model_lunaris.json").string();
+                   } else if (model_fs_path.filename().string().find("bpe_model_lunaris.json") != std::string::npos) {
+                       json_model_file_path = model_path_or_dir;
+                   } else {
+                       json_model_file_path = model_path_or_dir + "_bpe_model_lunaris.json";
+                       if (!fs::exists(json_model_file_path)) {
+                           json_model_file_path = (fs::path(model_path_or_dir).parent_path() / (fs::path(model_path_or_dir).filename().string() + "_bpe_model_lunaris.json")).string();
+                           if (!fs::exists(json_model_file_path)) {
+                               json_model_file_path = (fs::path(model_path_or_dir) / "bpe_model_lunaris.json").string();
+                           }
+                       }
+                   }
+
+                   if (!fs::exists(json_model_file_path)) {
+                       consoleErr("Could not find BPE model JSON file at or derived from: " + model_path_or_dir + " (tried: " + json_model_file_path + ")");
+                       return false;
+                   }
+                   consoleLog("Loading BPE model from: " + json_model_file_path);
+
+                   std::ifstream json_file(json_model_file_path);
+                   if (!json_file.is_open()) {
+                       consoleErr("Could not open BPE model JSON file: " + json_model_file_path);
+                       return false;
+                   }
+
+                   json model_data;
+                   try {
+                       json_file >> model_data;
+                   } catch (json::parse_error& e) {
+                       consoleErr("Error parsing BPE model JSON: " + std::string(e.what()));
+                       return false;
+                   }
+
+                   if (model_data.contains("bpe_config") && model_data["bpe_config"].contains("mode")) {
+                       std::string mode_str = model_data["bpe_config"]["mode"];
+                       byte_level_processing_mode_ = (mode_str == "byte");
+                       // CORRECTED string concatenation for log
+                       consoleLog(std::string("  Model BPE mode loaded: ") + (byte_level_processing_mode_ ? "byte" : "word"));
+                   } else {
+                       consoleErr("Error: 'bpe_config.mode' not found in model JSON. Cannot determine tokenization mode.");
+                       return false;
+                   }
+
+                   if (model_data.contains("vocabulary_map") && model_data["vocabulary_map"].is_object()) {
+                       for (auto const& [token_str, id_val] : model_data["vocabulary_map"].items()) {
+                           if (!id_val.is_number_integer()) {
+                               consoleErr("  Error: Vocabulary ID for token '" + token_str + "' is not an integer.");
+                               return false;
+                           }
+                           int token_id = id_val.get<int>();
+                           token_to_id_[token_str] = token_id;
+                           id_to_token_[token_id] = token_str;
+                       }
+                       consoleLog("  Vocabulary loaded. Size: " + std::to_string(token_to_id_.size()));
+                   } else {
+                       consoleErr("Error: 'vocabulary_map' (object) not found or invalid in model JSON.");
+                       return false;
+                   }
+
+                   if (model_data.contains("merges") && model_data["merges"].is_array()) {
+                       for (const auto& merge_item : model_data["merges"]) {
+                           if (merge_item.is_array() && merge_item.size() == 2 &&
+                               merge_item[0].is_string() && merge_item[1].is_string()) {
+                               loaded_merges_for_tokenizing_.push_back({merge_item[0].get<std::string>(), merge_item[1].get<std::string>()});
+                               } else {
+                                   consoleErr("  Error: Invalid merge item format in model JSON.");
+                                   return false;
+                               }
+                       }
+                       consoleLog("  Merges loaded. Count: " + std::to_string(loaded_merges_for_tokenizing_.size()));
+                   } else {
+                       consoleErr("Error: 'merges' (array) not found or invalid in model JSON.");
+                       return false;
+                   }
+
+                   model_loaded_ = true;
+                   consoleLog("BPE model loaded successfully.");
+                   return true;
                }
 
 private:
     bool verbose_;
     std::vector<std::vector<std::string>> pretokenized_corpus_;
-    std::unordered_set<std::string> vocab_;
-    std::vector<std::pair<std::string, std::string>> learned_merges_;
+    std::unordered_set<std::string> training_vocab_;
+    std::vector<std::pair<std::string, std::string>> learned_merges_for_saving_;
     BpeStats stats_;
-    bool byte_level_training_mode_; // Stores the mode set at construction
+    bool byte_level_processing_mode_;
+
+    std::map<std::string, int> token_to_id_;
+    std::map<int, std::string> id_to_token_;
+    std::vector<std::pair<std::string, std::string>> loaded_merges_for_tokenizing_;
+    bool model_loaded_;
 
     void consoleLog(const std::string& message) const {
         if(verbose_) std::cout << "[INFO] " << message << std::endl;
@@ -184,10 +285,13 @@ private:
         std::string escaped_token;
         escaped_token.reserve(token.length());
         for (char c : token) {
-            if (std::isprint(static_cast<unsigned char>(c))) {
+            if (std::isprint(static_cast<unsigned char>(c)) && c != '\\') {
                 escaped_token += c;
-            } else {
-                char hex_repr[5]; // For "\\xHH\0"
+            } else if (c == '\\'){
+                escaped_token += "\\\\";
+            }
+            else {
+                char hex_repr[5];
                 snprintf(hex_repr, sizeof(hex_repr), "\\x%02X", static_cast<unsigned char>(c));
                 escaped_token += hex_repr;
             }
@@ -208,34 +312,27 @@ private:
         return true;
     }
 
-    // loadAndPretokenizeCorpus now uses the member variable this->byte_level_training_mode_
     bool loadAndPretokenizeCorpus(const std::string& corpus_path) {
         std::ifstream file(corpus_path);
         if (!file.is_open()) {
             consoleErr("Could not open corpus file: " + corpus_path);
             return false;
         }
-
         pretokenized_corpus_.clear();
         stats_.initial_token_count_in_corpus = 0;
         stats_.raw_corpus_char_count = 0;
-
         std::string line;
         size_t line_number = 0;
-
         while (std::getline(file, line)) {
             line_number++;
             stats_.raw_corpus_char_count += line.length() + 1;
-
             if (line.empty()) {
                 if(verbose_ && line_number % 50000 == 0) consoleLog("Processed " + std::to_string(line_number) + " lines...");
                 continue;
             }
-
             std::vector<std::string> current_line_tokens;
-            current_line_tokens.reserve(line.length()); // Pre-allocate assuming worst case (byte-level)
-
-            if (this->byte_level_training_mode_) {
+            current_line_tokens.reserve(line.length());
+            if (this->byte_level_processing_mode_) {
                 for (unsigned char c : line) {
                     std::string byte_token_str;
                     if (c >= 32 && c <= 126) {
@@ -256,39 +353,35 @@ private:
                     }
                 }
             }
-
             if (!current_line_tokens.empty()) {
                 pretokenized_corpus_.push_back(std::move(current_line_tokens));
-                // Correctly update stats after move
                 stats_.initial_token_count_in_corpus += pretokenized_corpus_.back().size();
             }
             if(verbose_ && line_number % 50000 == 0) consoleLog("Processed " + std::to_string(line_number) + " lines... Current initial tokens: " + std::to_string(stats_.initial_token_count_in_corpus));
         }
         file.close();
-
         if (pretokenized_corpus_.empty() && stats_.raw_corpus_char_count > 0) {
             consoleLog("Warning: Corpus was read but resulted in no pre-tokenized sequences. Check input or pre-tokenization logic.");
         }
-        return !pretokenized_corpus_.empty() || stats_.raw_corpus_char_count == 0; // True if empty file or successfully tokenized
+        return !pretokenized_corpus_.empty() || stats_.raw_corpus_char_count == 0;
     }
 
-    // initializeVocabularyFromPretokenizedCorpus now uses the member variable
     void initializeVocabularyFromPretokenizedCorpus() {
-        vocab_.clear();
-        if (this->byte_level_training_mode_) {
-            for (int i = 0; i < 128; ++i) { // Base ASCII (0-127)
-                if (i >= 32 && i <= 126) { // Printable ASCII
-                    vocab_.insert(std::string(1, static_cast<char>(i)));
-                } else { // Control characters and space (if not caught by printable)
+        training_vocab_.clear();
+        if (this->byte_level_processing_mode_) {
+            for (int i = 0; i < 128; ++i) {
+                if (i >= 32 && i <= 126) {
+                    training_vocab_.insert(std::string(1, static_cast<char>(i)));
+                } else {
                     char hex_buf[5];
                     snprintf(hex_buf, sizeof(hex_buf), "\\x%02X", static_cast<unsigned char>(i));
-                    vocab_.insert(hex_buf);
+                    training_vocab_.insert(hex_buf);
                 }
             }
         }
         for (const auto& sentence_tokens : pretokenized_corpus_) {
             for (const auto& token : sentence_tokens) {
-                vocab_.insert(token);
+                training_vocab_.insert(token);
             }
         }
     }
@@ -308,7 +401,6 @@ private:
         const std::map<std::pair<std::string, std::string>, size_t>& pair_counts) {
         std::pair<std::pair<std::string, std::string>, size_t> best_pair_info = {{std::string(), std::string()}, 0};
         if (pair_counts.empty()) return best_pair_info;
-
         for (const auto& entry : pair_counts) {
             if (entry.second > best_pair_info.second) {
                 best_pair_info = entry;
@@ -321,10 +413,8 @@ private:
             size_t new_total_token_count = 0;
             for (auto& sentence_tokens : pretokenized_corpus_) {
                 if (sentence_tokens.empty()) continue;
-
                 std::vector<std::string> new_sentence_tokens;
                 new_sentence_tokens.reserve(sentence_tokens.size());
-
                 size_t i = 0;
                 while (i < sentence_tokens.size()) {
                     if (i + 1 < sentence_tokens.size() &&
@@ -340,7 +430,7 @@ private:
                 sentence_tokens = std::move(new_sentence_tokens);
                 new_total_token_count += sentence_tokens.size();
             }
-            stats_.initial_token_count_in_corpus = new_total_token_count; // Update with new compressed count
+            stats_.initial_token_count_in_corpus = new_total_token_count;
         }
 
         void printStats() const {
@@ -354,34 +444,45 @@ private:
             consoleLog("===============================\n");
         }
 
-        void saveResults(const std::string& output_dir) {
+        void saveTrainingResults(const std::string& actual_output_dir, const std::string& file_prefix) {
             json output_json;
-            std::vector<std::string> vocab_list(vocab_.begin(), vocab_.end());
-            std::sort(vocab_list.begin(), vocab_list.end());
-            output_json["vocabulary"] = vocab_list;
+
+            std::vector<std::string> sorted_vocab_list(training_vocab_.begin(), training_vocab_.end());
+            std::sort(sorted_vocab_list.begin(), sorted_vocab_list.end());
+
+            json vocab_map_json = json::object();
+            token_to_id_.clear();
+            id_to_token_.clear();
+            for (int i = 0; i < static_cast<int>(sorted_vocab_list.size()); ++i) { // Cast to int for loop
+                const std::string& token = sorted_vocab_list[i];
+                vocab_map_json[token] = i;
+                token_to_id_[token] = i;
+                id_to_token_[i] = token;
+            }
+            output_json["vocabulary_map"] = vocab_map_json;
+            output_json["vocabulary_size"] = sorted_vocab_list.size();
 
             json merges_list_json = json::array();
-            for (const auto& merge_pair : learned_merges_) {
-                // Save merges with escaped tokens for display consistency
-                merges_list_json.push_back({escapeTokenForDisplay(merge_pair.first), escapeTokenForDisplay(merge_pair.second)});
+            for (const auto& merge_pair : learned_merges_for_saving_) {
+                merges_list_json.push_back({merge_pair.first, merge_pair.second});
             }
             output_json["merges"] = merges_list_json;
 
-            // Save the mode used for training, so a tokenizer loading this can know.
             output_json["bpe_config"] = {
-                {"mode", this->byte_level_training_mode_ ? "byte" : "word"}
+                {"mode", this->byte_level_processing_mode_ ? "byte" : "word"}
             };
 
             output_json["stats"] = {
                 {"raw_corpus_char_count", stats_.raw_corpus_char_count},
                 {"final_token_count_in_corpus", stats_.initial_token_count_in_corpus},
                 {"initial_vocab_size", stats_.initial_vocab_size},
-                {"final_vocab_size", stats_.final_vocab_size},
-                {"total_merges", stats_.total_merges},
+                {"final_vocab_size_from_training_set", stats_.final_vocab_size},
+                {"actual_merges_performed", stats_.total_merges},
                 {"training_time_ms", stats_.training_time.count()}
             };
 
-            std::string json_model_path = fs::path(output_dir) / "bpe_model_lunaris.json";
+            std::string json_model_filename = file_prefix + "bpe_model_lunaris.json";
+            std::string json_model_path = (fs::path(actual_output_dir) / json_model_filename).string();
             std::ofstream json_out_file(json_model_path);
             if (json_out_file.is_open()) {
                 json_out_file << std::setw(2) << output_json << std::endl;
@@ -390,22 +491,23 @@ private:
                 consoleErr("Failed to save BPE model JSON to: " + json_model_path);
             }
 
-            // Save vocabulary and merges also as plain text for easier inspection
-            std::string vocab_text_path = fs::path(output_dir) / "vocabulary_lunaris.txt";
+            std::string vocab_text_filename = file_prefix + "vocabulary_lunaris.txt";
+            std::string vocab_text_path = (fs::path(actual_output_dir) / vocab_text_filename).string();
             std::ofstream vocab_out_file(vocab_text_path);
             if (vocab_out_file.is_open()) {
-                for (const auto& token : vocab_list) { // vocab_list is already sorted
-                    vocab_out_file << escapeTokenForDisplay(token) << "\n";
+                for (int i = 0; i < static_cast<int>(sorted_vocab_list.size()); ++i) { // Cast to int for loop
+                    vocab_out_file << escapeTokenForDisplay(sorted_vocab_list[i]) << "\n";
                 }
                 consoleLog("Vocabulary (TXT) saved to: " + vocab_text_path);
             } else {
                 consoleErr("Failed to save vocabulary TXT to: " + vocab_text_path);
             }
 
-            std::string merges_text_path = fs::path(output_dir) / "merges_lunaris.txt";
+            std::string merges_text_filename = file_prefix + "merges_lunaris.txt";
+            std::string merges_text_path = (fs::path(actual_output_dir) / merges_text_filename).string();
             std::ofstream merges_out_file(merges_text_path);
             if (merges_out_file.is_open()) {
-                for (const auto& merge_pair : learned_merges_) {
+                for (const auto& merge_pair : learned_merges_for_saving_) {
                     merges_out_file << escapeTokenForDisplay(merge_pair.first) << " " << escapeTokenForDisplay(merge_pair.second) << "\n";
                 }
                 consoleLog("Merges (TXT) saved to: " + merges_text_path);
@@ -415,91 +517,63 @@ private:
         }
 };
 
-
-// CLI Argument Parsing Structure
 struct CliArgs {
-    std::string corpus_path;
-    std::string output_dir = "./bpe_lunaris_model";
+    std::string action = "train";
+    std::string corpus_path_or_input_text;
+    std::string input_file_path;
+    std::string model_path;
+    std::string output_path_or_dir = "./bpe_lunaris_model";
     size_t vocab_size = 32000;
-    bool byte_level_mode = true; // Renamed to avoid conflict with BpeTrainer member
+    bool byte_level_mode = true;
     bool verbose = false;
 };
 
-// CLI Help Function
 void printHelp(const char* app_name) {
-    std::cout << "Lunaris BPE Trainer - Byte Pair Encoding Tokenizer Trainer\n\n";
-    std::cout << "Usage: " << app_name << " --corpus <filepath> [options]\n\n";
-    std::cout << "Required Arguments:\n";
-    std::cout << "  --corpus FILE      Path to the input corpus text file.\n\n";
-    std::cout << "Optional Arguments:\n";
-    std::cout << "  --output DIR       Output directory for model files (vocabulary, merges, JSON).\n"
-    << "                     (Default: ./bpe_lunaris_model)\n";
-    std::cout << "  --vocab-size N     Target vocabulary size.\n"
-    << "                     (Default: 32000)\n";
-    std::cout << "  --mode LEVEL       Tokenization mode: 'byte' or 'word'.\n"
-    << "                     'byte': Initial tokens are individual bytes (UTF-8 safe hex for non-printable/non-ASCII).\n"
-    << "                     'word': Initial tokens are space-separated words.\n"
-    << "                     (Default: byte)\n";
-    std::cout << "  --verbose          Enable verbose logging output during training.\n";
-    std::cout << "  -h, --help         Display this help message and exit.\n\n";
-    std::cout << "Example:\n";
-    std::cout << "  " << app_name << " --corpus my_data.txt --vocab-size 20000 --output ./my_bpe_model --verbose\n";
+    std::cout << "Lunaris BPE Processor - Train, Tokenize, Detokenize\n\n";
+    std::cout << "Usage: " << app_name << " --action <train|tokenize|detokenize> [options...]\n\n";
+    std::cout << "Actions:\n";
+    std::cout << "  train: Trains a new BPE model.\n";
+    std::cout << "    Required: --corpus <filepath>\n";
+    std::cout << "    Optional: --output <dir_or_prefix>, --vocab-size <N>, --mode <byte|word>, --verbose\n";
+    std::cout << "  tokenize: Tokenizes input text using a trained model.\n";
+    std::cout << "    Required: --model_path <path_to_model_dir_or_prefix>, --input_text \"<text>\" (or --input_file <filepath>)\n";
+    std::cout << "    Optional: --verbose\n";
+    std::cout << "\nCommon Options:\n";
+    std::cout << "  -h, --help         Display this help message and exit.\n";
 }
 
-// CLI Argument Parsing Function
 bool parseCliArguments(int argc, char* argv[], CliArgs& cli_args) {
-    if (argc == 1) {
-        printHelp(argv[0]);
-        return false;
-    }
+    if (argc == 1) { printHelp(argv[0]); return false; }
     for (int i = 1; i < argc; ++i) {
         std::string arg = argv[i];
-        if (arg == "-h" || arg == "--help") {
-            printHelp(argv[0]);
-            return false;
-        } else if (arg == "--corpus" && i + 1 < argc) {
-            cli_args.corpus_path = argv[++i];
-        } else if (arg == "--output" && i + 1 < argc) {
-            cli_args.output_dir = argv[++i];
-        } else if (arg == "--vocab-size" && i + 1 < argc) {
-            try {
-                unsigned long val = std::stoul(argv[++i]); // Use unsigned long for stoul
-                if (val == 0) { throw std::invalid_argument("Vocabulary size must be greater than zero.");}
-                cli_args.vocab_size = static_cast<size_t>(val);
-            } catch (const std::exception& e) {
-                std::cerr << "[ERROR] Invalid vocabulary size: " << argv[i-1] << " (Value: " << argv[i] << "). Error: " << e.what() << "\n";
-                return false;
-            }
-        } else if (arg == "--mode" && i + 1 < argc) {
-            std::string mode_str = argv[++i];
-            std::transform(mode_str.begin(), mode_str.end(), mode_str.begin(), ::tolower); // Convert to lowercase
-            if (mode_str == "byte") {
-                cli_args.byte_level_mode = true;
-            } else if (mode_str == "word") {
-                cli_args.byte_level_mode = false;
-            } else {
-                std::cerr << "[ERROR] Invalid mode: '" << mode_str << "'. Choose 'byte' or 'word'.\n";
-                return false;
-            }
-        } else if (arg == "--verbose") {
-            cli_args.verbose = true;
-        } else {
-            std::cerr << "[ERROR] Unknown argument or missing value: " << arg << "\n";
+        if (arg == "-h" || arg == "--help") { printHelp(argv[0]); return false; }
+        else if (arg == "--action" && i + 1 < argc) { cli_args.action = argv[++i]; }
+        else if (arg == "--corpus" && i + 1 < argc) { cli_args.corpus_path_or_input_text = argv[++i]; }
+        else if (arg == "--input_text" && i + 1 < argc) { cli_args.corpus_path_or_input_text = argv[++i];}
+        else if (arg == "--input_file" && i + 1 < argc) { cli_args.input_file_path = argv[++i];}
+        else if (arg == "--model_path" && i + 1 < argc) { cli_args.model_path = argv[++i]; }
+        else if (arg == "--output" && i + 1 < argc) { cli_args.output_path_or_dir = argv[++i]; }
+        else if (arg == "--vocab-size" && i + 1 < argc) { cli_args.vocab_size = std::stoul(argv[++i]); }
+        else if (arg == "--mode" && i + 1 < argc) { cli_args.byte_level_mode = (std::string(argv[++i]) == "byte");}
+        else if (arg == "--verbose") { cli_args.verbose = true; }
+        else { // Basic unknown argument handling
+            std::cerr << "[ERROR] Unknown or incomplete argument: " << arg << std::endl;
             printHelp(argv[0]);
             return false;
         }
     }
-
-    if (cli_args.corpus_path.empty()) {
-        std::cerr << "[ERROR] Corpus path (--corpus) is required.\n";
-        printHelp(argv[0]);
-        return false;
+    if (cli_args.action == "train" && cli_args.corpus_path_or_input_text.empty()) {
+        std::cerr << "[ERROR] For action 'train', --corpus is required.\n"; return false;
+    }
+    if (cli_args.action == "tokenize" && cli_args.model_path.empty()) {
+        std::cerr << "[ERROR] For action 'tokenize', --model_path is required.\n"; return false;
+    }
+    if (cli_args.action == "tokenize" && cli_args.corpus_path_or_input_text.empty() && cli_args.input_file_path.empty()) {
+        std::cerr << "[ERROR] For action 'tokenize', either --input_text or --input_file is required.\n"; return false;
     }
     return true;
 }
 
-
-// Main function
 int main(int argc, char* argv[]) {
     std::ios_base::sync_with_stdio(false);
     std::cin.tie(NULL);
@@ -509,19 +583,43 @@ int main(int argc, char* argv[]) {
         return 1;
     }
 
-    // Pass the byte_level_mode from CLI to the BpeTrainer constructor
-    BpeTrainer trainer(cli_args.verbose, cli_args.byte_level_mode);
+    BpeProcessor processor(cli_args.verbose);
 
-    // The train method no longer needs byte_level as it's part of the trainer's state
-    bool success = trainer.train(cli_args.corpus_path,
-                                 cli_args.output_dir,
-                                 cli_args.vocab_size);
+    if (cli_args.action == "train") {
+        bool success = processor.train(cli_args.corpus_path_or_input_text,
+                                       cli_args.output_path_or_dir,
+                                       cli_args.vocab_size,
+                                       cli_args.byte_level_mode);
+        if(success && cli_args.verbose) {
+            std::cout << "[SUCCESS] BPE training completed successfully.\n";
+        } else if (!success && !cli_args.verbose) { // Print failure even if not verbose
+            std::cout << "[FAILURE] BPE training encountered an error or produced no results.\n";
+        } else if (!success && cli_args.verbose){
+            // verbose already printed errors
+        }
+        return success ? 0 : 1;
+    } else if (cli_args.action == "tokenize") {
+        if (!processor.load_model(cli_args.model_path)) {
+            std::cerr << "[FAILURE] Could not load BPE model for tokenization.\n";
+            return 1;
+        }
+        std::string text_to_tokenize;
+        if (!cli_args.input_file_path.empty()) {
+            std::ifstream ifs(cli_args.input_file_path);
+            if (!ifs) { std::cerr << "Error opening input file: " << cli_args.input_file_path << std::endl; return 1;}
+            std::stringstream buffer;
+            buffer << ifs.rdbuf();
+            text_to_tokenize = buffer.str();
+        } else {
+            text_to_tokenize = cli_args.corpus_path_or_input_text;
+        }
 
-    if(success && cli_args.verbose) { // Only print success if verbose
-        std::cout << "[SUCCESS] BPE training completed successfully.\n";
-    } else if (!success) { // Always print failure
-        std::cout << "[FAILURE] BPE training encountered an error or produced no results.\n";
+        std::cout << "[INFO] Tokenize action called. Input (first 50 chars): '" << text_to_tokenize.substr(0, 50) << (text_to_tokenize.length() > 50 ? "..." : "") << "'. Actual tokenization not yet implemented in this step.\n";
+        return 0;
     }
-
-    return success ? 0 : 1;
+    else {
+        std::cerr << "[ERROR] Unknown action: " << cli_args.action << std::endl;
+        printHelp(argv[0]);
+        return 1;
+    }
 }


### PR DESCRIPTION
This PR introduces significant structural changes to the BPE utility, renaming `BpeTrainer` to `BpeProcessor` to reflect its expanded role beyond just training. It lays the groundwork for future tokenization and detokenization capabilities.

**Key Changes (developed in collaboration with Google's Gemini):**

*   **Class Renaming:** `BpeTrainer` is now `BpeProcessor`.
*   **New Class Members:** Added members to `BpeProcessor` to store a loaded BPE model's vocabulary (`token_to_id_`, `id_to_token_`) and merge rules (`loaded_merges_for_tokenizing_`).
*   **Modified Model Saving (`saveTrainingResults`):**
    *   The vocabulary is now saved as a `vocabulary_map` (object/map of `{"token": id}`) in the `bpe_model_lunaris.json` file for easier loading.
    *   Merges in the JSON are now stored with their original (non-escaped) token strings.
*   **New Function `load_model()`:** Implemented to parse the `bpe_model_lunaris.json` (with the new `vocabulary_map` format) and populate the internal structures for a loaded model.
*   **CLI Updates:**
    *   Introduced an `--action` argument (`train`, `tokenize`).
    *   Added arguments (`--model_path`, `--input_text`, `--input_file`) for the (future) `tokenize` action.
    *   The `main` function now routes to training or model loading based on the specified action.
*   **Placeholder for `tokenize()`:** A placeholder for the actual tokenization logic has been added.

**Testing:**
- Successfully compiled.
- Training a new BPE model works as before, and the new JSON model format (with `vocabulary_map`) is saved correctly.
- The `load_model()` function successfully loads the newly formatted JSON model when using `--action tokenize`.

This PR prepares the `BpeProcessor` for the implementation of the core tokenization algorithm.